### PR TITLE
Add output directory options

### DIFF
--- a/exe/rspec_n
+++ b/exe/rspec_n
@@ -15,6 +15,7 @@ lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "cri"
+require "fileutils"
 require "rspec_n/version"
 require "rspec_n/constants"
 require "rspec_n/errors/bad_option"
@@ -40,6 +41,13 @@ command = Cri::Command.define do
   option :c, :command, command_description, argument: :required
 
   flag nil, "no-file", "Do not write iteration output to files"
+
+  flag nil, "timestamp", "Write iteration output to a timestamped directory, which can " \
+    "prevent accidental loss. NOTE: It is up to the user to periodically clean up files."
+
+  command_description = "Write iteration output to files in the provided directory " \
+    "rather than the current working directory. Can be used along with the timestamp flag."
+  option :d, :dir, command_description, argument: :required
 
   flag :s, "stop-fast", "Stop when an iteration reports a failure."
 

--- a/lib/rspec_n/formatters/file_formatter.rb
+++ b/lib/rspec_n/formatters/file_formatter.rb
@@ -12,16 +12,19 @@ module RspecN
       end
 
       def delete_all_files
-        Dir.glob("#{BASE_FILE_NAME}.**").each { |file| File.delete(file) }
+        log_directory = Pathname.new(@runner.input.log_path)
+        Dir.glob(log_directory.join("#{BASE_FILE_NAME}.**")).each { |file| File.delete(file) }
       end
 
       def write(run, command)
         return if run.skipped?
         return unless @runner.input.write_files?
 
-        file_name = "#{BASE_FILE_NAME}.#{run.iteration}"
+        log_directory = Pathname.new(@runner.input.log_path)
+        FileUtils.mkdir_p(log_directory)
+        file_path = log_directory.join("#{BASE_FILE_NAME}.#{run.iteration}")
 
-        File.open(file_name, "w") do |f|
+        File.open(file_path, "w") do |f|
           f.write("Iteration: #{run.iteration}\n")
           f.write("Start Time: #{run.formatted_start_time(@format)}\n")
           f.write("Finish Time: #{run.formatted_finish_time(@format)}\n")

--- a/lib/rspec_n/input.rb
+++ b/lib/rspec_n/input.rb
@@ -1,6 +1,6 @@
 module RspecN
   class Input
-    attr_accessor :iterations, :command, :stop_fast, :write_files
+    attr_accessor :iterations, :command, :stop_fast, :write_files, :log_path
     def initialize(options, args)
       @args = args
       @unprocessed_args_array = args.entries
@@ -12,6 +12,8 @@ module RspecN
       @command = determine_command
       @stop_fast = options.fetch(:"stop-fast", false)
       @write_files = !options.fetch(:'no-file', false)
+      @timestamp = options.fetch(:timestamp, false)
+      @log_path = determine_log_path
     end
 
     def write_files?
@@ -69,6 +71,15 @@ module RspecN
       return false if @order == "project"
 
       command.match(/--order/).nil?
+    end
+
+    def determine_log_path
+      log_path = Pathname.new(@options.fetch(:dir, Dir.pwd))
+      return log_path unless @timestamp
+
+      directory_name = File.basename($PROGRAM_NAME)
+      directory_name << "-#{Time.now.getlocal.strftime('%Y%m%d%H%M%S%L')}"
+      log_path.join(directory_name)
     end
   end
 end


### PR DESCRIPTION
Add ability to save output files to a timestamped directory to prevent files from accidentally being overwritten.
Add ability to specify a directory in which to save output files.