### PR TITLE
Fix import of Pathname

### DIFF
--- a/lib/rspec_n.rb
+++ b/lib/rspec_n.rb
@@ -3,6 +3,7 @@ require "rspec_n/version"
 require "colorize"
 require "cri"
 require "open3"
+require "pathname"
 
 require "rspec_n/helpers/time_helpers"
 require "rspec_n/helpers/core_ext/array"


### PR DESCRIPTION
Without that I get
/usr/local/bundle/gems/rspec_n-1.3.0/lib/rspec_n/input.rb:77:in `determine_log_path': uninitialized constant RspecN::Input::Pathname (NameError)