### PR TITLE
[#93] Make Ruby 2.7.0 the min supported Ruby

### DIFF
--- a/.github/workflows/check_pull_request.yml
+++ b/.github/workflows/check_pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.7', '3.0']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6']
+        ruby-version: ['2.7']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ inherit_gem:
 # do not attempt to merge these settings with their defaults. Long term changes should be ported to the rubocop_plus gem.
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Style/Documentation:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Issues are tracked at https://github.com/roberts1000/rspec_n/issues. Issues mark
 ## Next Release
 
 1. [#87](../../issues/87): Add GitHub action workflow to check pull requests. **(Internal)**
+1. [#93](../../issues/93): Make Ruby 2.7.0 the min supported Ruby.
 
 ## 1.4.0 (May 16, 2021)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Releases are versioned using [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html)
 
 ## Supported Ruby Versions
 
-Ruby 2.6.0+
+Ruby 2.7.0+
 
 ## Installation
 

--- a/rspec_n.gemspec
+++ b/rspec_n.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.14.0"


### PR DESCRIPTION
Closes #93 